### PR TITLE
Combined small fixes

### DIFF
--- a/calcpedersenbases/calcpedersenbases.js
+++ b/calcpedersenbases/calcpedersenbases.js
@@ -1,14 +1,15 @@
 const bn128 = require("snarkjs").bn128;
 const bigInt = require("snarkjs").bigInt;
 const createBlakeHash = require("blake-hash");
-const assert = require("assert");
 const babyJub = require("../src/babyjub");
 
 function getPoint(S) {
     const F = bn128.Fr;
     const h = createBlakeHash("blake256").update(S).digest();
 
-    assert(h.length == 32);
+    if (h.length != 32) {
+        throw new Error("Invalid length")
+    }
 
     let sign = false;
     if (h[31] & 0x80) {
@@ -52,7 +53,9 @@ function generatePoint(S) {
         p = getPoint(S+"_"+sidx);
         idx++;
     }
-    assert(babyJub.inCurve(p), "Point not in curve");
+    if (!babyJub.inCurve(p)){
+        throw new Error("Point not in curve");
+    }
     return p;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.smt = require("./src/smt");
 exports.eddsa = require("./src/eddsa");
 exports.mimc7 = require("./src/mimc7");
+exports.babyJub = require("./src/babyjub");

--- a/src/eddsa.js
+++ b/src/eddsa.js
@@ -3,9 +3,7 @@ const bigInt = require("snarkjs").bigInt;
 const babyJub = require("./babyjub");
 const pedersenHash = require("./pedersenHash").hash;
 const mimc7 = require("./mimc7");
-const crypto = require("crypto");
     
-exports.cratePrvKey = cratePrvKey;
 exports.prv2pub= prv2pub;
 exports.sign = sign;
 exports.signMiMC = signMiMC;
@@ -15,10 +13,6 @@ exports.packSignature = packSignature;
 exports.unpackSignature = unpackSignature;
 exports.pruneBuffer = pruneBuffer;
 
-
-function cratePrvKey() {
-    return crypto.randomBytes(32);
-}
 
 function pruneBuffer(_buff) {
     const buff = Buffer.from(_buff);

--- a/src/eddsa.js
+++ b/src/eddsa.js
@@ -4,7 +4,7 @@ const babyJub = require("./babyjub");
 const pedersenHash = require("./pedersenHash").hash;
 const mimc7 = require("./mimc7");
 const crypto = require("crypto");
-
+    
 exports.cratePrvKey = cratePrvKey;
 exports.prv2pub= prv2pub;
 exports.sign = sign;
@@ -13,6 +13,7 @@ exports.verify = verify;
 exports.verifyMiMC = verifyMiMC;
 exports.packSignature = packSignature;
 exports.unpackSignature = unpackSignature;
+exports.pruneBuffer = pruneBuffer;
 
 
 function cratePrvKey() {

--- a/src/evmasm.js
+++ b/src/evmasm.js
@@ -3,7 +3,7 @@
 //
 
 
-const Web3 = require("web3");
+const Web3Utils = require("web3-utils");
 const assert = require("assert");
 
 class Contract {
@@ -39,7 +39,7 @@ class Contract {
             genLoadedLength = C.code.length;
         }
 
-        return Web3.utils.bytesToHex(C.code.concat(this.code));
+        return Web3Utils.bytesToHex(C.code.concat(this.code));
     }
 
     stop() { this.code.push(0x00); }
@@ -149,7 +149,7 @@ class Contract {
     }
 
     push(data) {
-        const d = Web3.utils.hexToBytes(Web3.utils.toHex(data));
+        const d = Web3Utils.hexToBytes(Web3Utils.toHex(data));
         assert(d.length>0);
         assert(d.length<=32);
         this.code = this.code.concat([0x5F + d.length], d);

--- a/src/evmasm.js
+++ b/src/evmasm.js
@@ -4,7 +4,6 @@
 
 
 const Web3Utils = require("web3-utils");
-const assert = require("assert");
 
 class Contract {
     constructor() {
@@ -141,7 +140,9 @@ class Contract {
     msize()  { this.code.push(0x59); }
     gas()  { this.code.push(0x5a); }
     label(name)  {
-        assert(typeof this.labels[name] == "undefined", "Label already defined");
+        if (typeof this.labels[name] != "undefined") {
+            throw new Error("Label already defined");
+        }
         this.labels[name] = this.code.length;
         this.code.push(0x5b);
 
@@ -150,20 +151,23 @@ class Contract {
 
     push(data) {
         const d = Web3Utils.hexToBytes(Web3Utils.toHex(data));
-        assert(d.length>0);
-        assert(d.length<=32);
+        if (d.length == 0 || d.length > 32) {
+            throw new Error("Assertion failed");
+        }
         this.code = this.code.concat([0x5F + d.length], d);
     }
 
     dup(n) {
-        assert(n>=0);
-        assert(n<16);
+        if (n < 0 || n >= 16) {
+            throw new Error("Assertion failed");
+        }
         this.code.push(0x80 + n);
     }
 
     swap(n) {
-        assert(n>=1);
-        assert(n<=16);
+        if (n < 1 || n > 16) {
+            throw new Error("Assertion failed");
+        }
         this.code.push(0x8f + n);
     }
 

--- a/src/mimc7.js
+++ b/src/mimc7.js
@@ -1,6 +1,6 @@
 const bn128 = require("snarkjs").bn128;
 const bigInt = require("snarkjs").bigInt;
-const Web3 = require("web3");
+const Web3Utils = require("web3-utils");
 const F = bn128.Fr;
 
 const SEED = "mimc";
@@ -8,8 +8,8 @@ const NROUNDS = 91;
 
 exports.getIV = (seed) => {
     if (typeof seed === "undefined") seed = SEED;
-    const c = Web3.utils.keccak256(seed+"_iv");
-    const cn = bigInt(Web3.utils.toBN(c).toString());
+    const c = Web3Utils.keccak256(seed+"_iv");
+    const cn = bigInt(Web3Utils.toBN(c).toString());
     const iv = cn.mod(F.q);
     return iv;
 };
@@ -18,13 +18,13 @@ exports.getConstants = (seed, nRounds) => {
     if (typeof seed === "undefined") seed = SEED;
     if (typeof nRounds === "undefined") nRounds = NROUNDS;
     const cts = new Array(nRounds);
-    let c = Web3.utils.keccak256(SEED);
+    let c = Web3Utils.keccak256(SEED);
     for (let i=1; i<nRounds; i++) {
-        c = Web3.utils.keccak256(c);
+        c = Web3Utils.keccak256(c);
 
-        const n1 = Web3.utils.toBN(c).mod(Web3.utils.toBN(F.q.toString()));
-        const c2 = Web3.utils.padLeft(Web3.utils.toHex(n1), 64);
-        cts[i] = bigInt(Web3.utils.toBN(c2).toString());
+        const n1 = Web3Utils.toBN(c).mod(Web3Utils.toBN(F.q.toString()));
+        const c2 = Web3Utils.padLeft(Web3Utils.toHex(n1), 64);
+        cts[i] = bigInt(Web3Utils.toBN(c2).toString());
     }
     cts[0] = bigInt(0);
     return cts;

--- a/src/mimc_gencontract.js
+++ b/src/mimc_gencontract.js
@@ -2,13 +2,13 @@
 // License: LGPL-3.0+
 //
 
-const Web3 = require("web3");
+const Web3Utils = require("web3-utils");
 
 const Contract = require("./evmasm");
 
 function createCode(seed, n) {
 
-    let ci = Web3.utils.keccak256(seed);
+    let ci = Web3Utils.keccak256(seed);
 
     const C = new Contract();
 
@@ -51,7 +51,7 @@ function createCode(seed, n) {
     C.mulmod();         // r=t^7 k q
 
     for (let i=0; i<n-1; i++) {
-        ci = Web3.utils.keccak256(ci);
+        ci = Web3Utils.keccak256(ci);
         C.dup(2);       // q r k q
         C.dup(0);       // q q r k q
         C.dup(0);       // q q q r k q

--- a/src/pedersenHash.js
+++ b/src/pedersenHash.js
@@ -1,7 +1,6 @@
 const bn128 = require("snarkjs").bn128;
 const bigInt = require("snarkjs").bigInt;
 const babyJub = require("./babyjub");
-const assert = require("assert");
 const createBlakeHash = require("blake-hash");
 
 const GENPOINT_PREFIX = "PedersenGenerator";
@@ -73,7 +72,9 @@ function getBasePoint(pointIdx) {
 
     const p8 = babyJub.mulPointEscalar(p, 8);
 
-    assert(babyJub.inSubgroup(p8), "Point not in curve");
+    if (!babyJub.inSubgroup(p8)) {
+        throw new Error("Point not in curve");
+    }
 
     bases[pointIdx] = p8;
     return p8;

--- a/test/eddsa.js
+++ b/test/eddsa.js
@@ -2,6 +2,7 @@ const chai = require("chai");
 const path = require("path");
 const snarkjs = require("snarkjs");
 const compiler = require("circom");
+// const crypto = require("crypto");
 
 const eddsa = require("../src/eddsa.js");
 const babyJub = require("../src/babyjub.js");
@@ -45,7 +46,7 @@ describe("EdDSA test", function () {
     it("Sign a single 10 bytes from 0 to 9", async () => {
         const msg = Buffer.from("00010203040506070809", "hex");
 
-//        const prvKey = eddsa.cratePrvKey();
+//        const prvKey = crypto.randomBytes(32);
 
         const prvKey = Buffer.from("0001020304050607080900010203040506070809000102030405060708090001", "hex");
 


### PR DESCRIPTION
This PR addresses three points:

- Web3 beta 41 stopped exposing `Web3.utils`, so calls like `Web3.utils.bytesToHex` are broken. Importing `web3-utils` directly overcomes this problem.
- `babyJub.mulPointEscalar()` and `eddsa.pruneBuffer()` fail because they are not currently exposed
- Using `crypto` and `assert` NodeJS core modules may not work on other environments

There is one commit for each one of these. Changes can be cherry-picked if necessary. 
Testing runs clean.
Thank you