### PR TITLE
makes compconstant compatible with non-native bigint type

### DIFF
--- a/circuits/compconstant.circom
+++ b/circuits/compconstant.circom
@@ -47,11 +47,11 @@ template CompConstant(ct) {
         smsb = in[i*2+1];
 
 
-        if ((cmsb==0)&(clsb==0)) {
+        if (((cmsb==0)&(clsb==0)) == 1) {
             parts[i] <== -b*smsb*slsb + b*smsb + b*slsb;
-        } else if ((cmsb==0)&(clsb==1)) {
+        } else if (((cmsb==0)&(clsb==1)) == 1) {
             parts[i] <== a*smsb*slsb - a*slsb + b*smsb - a*smsb + a;
-        } else if ((cmsb==1)&(clsb==0)) {
+        } else if (((cmsb==1)&(clsb==0)) == 1) {
             parts[i] <== b*smsb*slsb - a*smsb + a;
         } else {
             parts[i] <== -a*smsb*slsb + a;


### PR DESCRIPTION
Currently, CompConstant has a series of `if` statements that check directly the result of bigint operations. snarkjs, in turn, generates javascript `if` statements on those bigints. With the native bigint, supported in recent node.js and chrome these work as expected, and on the non-native type it works incorrectly (bigInt(0) is not false-y).

Maybe there should be some additional protection in the code generation itself - e.g., if statements could check whether there's an assert in the expression? @jbaylina 