### PR TITLE
fixes babyjubjub addition to use generic bigint interfaces

### DIFF
--- a/src/babyjub.js
+++ b/src/babyjub.js
@@ -22,8 +22,14 @@ function addPoint(a,b) {
     const d = bigInt("168696");
 
     const res = [];
-    res[0] = bigInt((a[0]*b[1] + b[0]*a[1]) *  bigInt(bigInt("1") + d*a[0]*b[0]*a[1]*b[1]).inverse(q)).affine(q);
+
+    /* does the equivalent of:
+     res[0] = bigInt((a[0]*b[1] + b[0]*a[1]) *  bigInt(bigInt("1") + d*a[0]*b[0]*a[1]*b[1]).inverse(q)).affine(q);
     res[1] = bigInt((a[1]*b[1] - cta*a[0]*b[0]) * bigInt(bigInt("1") - d*a[0]*b[0]*a[1]*b[1]).inverse(q)).affine(q);
+    */
+    res[0] = bigInt((bigInt(a[0]).mul(b[1]).add(bigInt(b[0]).mul(a[1]))).mul(bigInt(bigInt("1").add(d.mul(a[0]).mul(b[0]).mul(a[1]).mul(b[1]))).inverse(q))).affine(q);
+    res[1] = bigInt((bigInt(a[1]).mul(b[1]).sub(cta.mul(a[0]).mul(b[0]))).mul(bigInt(bigInt("1").sub(d.mul(a[0]).mul(b[0]).mul(a[1]).mul(b[1]))).inverse(q))).affine(q);
+
     return res;
 }
 


### PR DESCRIPTION
Currently, the babyjubjub javascript code uses + and * for additions and multiplications. These work only on the native bigint type, and not on the non-native one. This replaces the operations with add and mul, which work on both types.