### PR TITLE
add tests for babyjub eddsa poseidon sign & verify

### DIFF
--- a/test/eddsa_js.js
+++ b/test/eddsa_js.js
@@ -12,7 +12,7 @@ describe("EdDSA js test", function () {
 
     this.timeout(100000);
 
-    it("Sign a single 10 bytes from 0 to 9", () => {
+    it("Sign (using Mimc7) a single 10 bytes from 0 to 9", () => {
         const msgBuf = Buffer.from("00010203040506070809", "hex");
         const msg = bigInt.leBuff2int(msgBuf);
 
@@ -44,6 +44,39 @@ describe("EdDSA js test", function () {
 
         const uSignature = eddsa.unpackSignature(pSignature);
         assert(eddsa.verifyMiMC(msg, uSignature, pubKey));
+
+    });
+
+    it("Sign (using Poseidon) a single 10 bytes from 0 to 9", () => {
+        const msgBuf = Buffer.from("00010203040506070809", "hex");
+        const msg = bigInt.leBuff2int(msgBuf);
+
+        const prvKey = Buffer.from("0001020304050607080900010203040506070809000102030405060708090001", "hex");
+
+        const pubKey = eddsa.prv2pub(prvKey);
+
+        assert.equal(pubKey[0].toString(),
+            "13277427435165878497778222415993513565335242147425444199013288855685581939618");
+        assert.equal(pubKey[1].toString(),
+            "13622229784656158136036771217484571176836296686641868549125388198837476602820");
+
+        const pPubKey = babyJub.packPoint(pubKey);
+
+        const signature = eddsa.signPoseidon(prvKey, msg);
+        assert.equal(signature.R8[0].toString(),
+            "11384336176656855268977457483345535180380036354188103142384839473266348197733");
+        assert.equal(signature.R8[1].toString(),
+            "15383486972088797283337779941324724402501462225528836549661220478783371668959");
+        assert.equal(signature.S.toString(),
+            "248298168863866362217836334079793350221620631973732197668910946177382043688");
+
+        const pSignature = eddsa.packSignature(signature);
+        assert.equal(pSignature.toString("hex"), ""+
+            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
+            "28506bce274aa1b3f7e7c2fd7e4fe09bff8f9aa37a42def7994e98f322888c00");
+
+        const uSignature = eddsa.unpackSignature(pSignature);
+        assert(eddsa.verifyPoseidon(msg, uSignature, pubKey));
 
     });
 });


### PR DESCRIPTION
Same test vectors than in https://github.com/iden3/go-iden3-crypto to check eddsa babyjubjub with Poseidon (sign&verify)