### PR TITLE
Put signal-dependent control-flow in compute block.

### DIFF
--- a/circuits/pointbits.circom
+++ b/circuits/pointbits.circom
@@ -94,16 +94,18 @@ template Bits2Point_Strict() {
 
     out[1] <== b2nY.out;
 
-    var a = 168700;
-    var d = 168696;
+    compute {
+        var a = 168700;
+        var d = 168696;
 
-    var y2 = out[1] * out[1];
+        var y2 = out[1] * out[1];
 
-    var x = sqrt(   (1-y2)/(a - d*y2)  );
+        var x = sqrt(   (1-y2)/(a - d*y2)  );
 
-    if (in[255] == 1) x = -x;
+        if (in[255] == 1) x = -x;
 
-    out[0] <-- x;
+        out[0] <-- x;
+    }
 
     component babyCheck = BabyCheck();
     babyCheck.x <== out[0];


### PR DESCRIPTION
pointbits contains an instance of signal-dependent control-flow: when
the control flow of the circom program depends on the value of a signal.

Since all signals are undefined at circuit-generation time, this is
has undefined semantics at circuit-generation time. However, during
compute time, it is important.

Thus, it should go in a `compute` block.