### PR TITLE
fix: improve LessThan and adds assert

### DIFF
--- a/circuits/comparators.circom
+++ b/circuits/comparators.circom
@@ -86,10 +86,11 @@ template LessThan(n) {
 */
 
 template LessThan(n) {
+    assert(n <= 252);
     signal input in[2];
     signal output out;
 
-    component n2b = Num2Bits(n*2+1);
+    component n2b = Num2Bits(n+1);
 
     n2b.in <== in[0]+ (1<<n) - in[1];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,6 +218,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -318,6 +323,11 @@
       "requires": {
         "nanoassert": "^1.0.0"
       }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -557,7 +567,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -568,7 +577,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -577,7 +585,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -585,8 +592,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
@@ -632,29 +638,53 @@
       }
     },
     "circom": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/circom/-/circom-0.5.10.tgz",
-      "integrity": "sha512-50cVHDG7EbkuS6Ht3SDKBDeR/2M+/XSUxfpJMBL1TmFO2B/ucwUIwBNS00bpdtkT080dqwOVtuiYTLQ27prImw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/circom/-/circom-0.5.21.tgz",
+      "integrity": "sha512-Om90wztN6Y4Gg5ks4n+iTKU/5bR1gkPyRPzEi5gtu0brbSqnKfAnYWp8d/U28h2353rj476I1KNArg/QVNzBaw==",
       "requires": {
         "chai": "^4.2.0",
-        "circom_runtime": "0.0.6",
-        "fastfile": "0.0.1",
-        "ffiasm": "0.0.2",
-        "ffjavascript": "0.1.0",
+        "circom_runtime": "0.1.4",
+        "fastfile": "0.0.12",
+        "ffiasm": "0.1.1",
+        "ffjavascript": "0.2.10",
         "ffwasm": "0.0.7",
         "fnv-plus": "^1.3.1",
-        "r1csfile": "0.0.5",
+        "r1csfile": "0.0.14",
         "tmp-promise": "^2.0.2",
         "wasmbuilder": "0.0.10"
+      },
+      "dependencies": {
+        "ffjavascript": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.10.tgz",
+          "integrity": "sha512-GQI6gHYYG5/iD4Kt3VzezzK7fARJzP0zkc82V/+JAdjfeKBXhDSo5rpKFuK3cDcrdW0Fu2emuYNMEAuFqhEQvQ==",
+          "requires": {
+            "big-integer": "^1.6.48",
+            "wasmcurves": "0.0.5",
+            "worker-threads": "^1.0.0"
+          }
+        }
       }
     },
     "circom_runtime": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.0.6.tgz",
-      "integrity": "sha512-o0T5MuWzxnxinWG3+CygS/kZouoP+z5ZrufUwqKJy3gsVFJhkbqMpfKmcBGjhExB3uatA7cKyOiRAOLOz5+t5w==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.4.tgz",
+      "integrity": "sha512-sQWeEBD3o2jIdrKPf3VDu7DNfP+NfscYO/pxi73FE0qQW8TXTfwno8Grdl++h6OKWbzvWJdG5jQvS+WGKjpMOg==",
       "requires": {
-        "ffjavascript": "0.1.0",
+        "ffjavascript": "0.2.10",
         "fnv-plus": "^1.3.1"
+      },
+      "dependencies": {
+        "ffjavascript": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.10.tgz",
+          "integrity": "sha512-GQI6gHYYG5/iD4Kt3VzezzK7fARJzP0zkc82V/+JAdjfeKBXhDSo5rpKFuK3cDcrdW0Fu2emuYNMEAuFqhEQvQ==",
+          "requires": {
+            "big-integer": "^1.6.48",
+            "wasmcurves": "0.0.5",
+            "worker-threads": "^1.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -1066,9 +1096,12 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.0.2.tgz",
-      "integrity": "sha512-IncmUpn1yN84hy2shb0POJ80FWrfGNY0cxO9f4v+/sG7qcBvAtVWUA1IdzY/8EYUmOVhoKJVdJjNd3AZcnxOjA=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==",
+      "requires": {
+        "jake": "^10.6.1"
+      }
     },
     "elliptic": {
       "version": "6.5.2",
@@ -1169,8 +1202,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
@@ -1755,9 +1787,9 @@
       "dev": true
     },
     "fastfile": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.1.tgz",
-      "integrity": "sha512-Fk8PWafGWGEUw7oPq/dJen92ASxknCEy4ZC8n4VEvSwCp/jcReyEmVoWsRIWTf+IvAp2MzvFi54vOPeK2LQZtQ=="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.12.tgz",
+      "integrity": "sha512-0EZo2y5eW8X0oiDDRvcnufjVxlM96CQL5hvmRQtbRABWlCkH73IHwkzl0qOSdxtchaMr+0TSB7GVqaVEixRr1Q=="
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -1768,9 +1800,9 @@
       }
     },
     "ffiasm": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ffiasm/-/ffiasm-0.0.2.tgz",
-      "integrity": "sha512-o/CL7F4IodB7eRHCOQL1SrqN2DIPHrQbEwjPY7NIyeBRdnB3G0xo6b6Mj44SKiWFnvpQMb3n4N7acjD3vv4NVQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ffiasm/-/ffiasm-0.1.1.tgz",
+      "integrity": "sha512-irMMHiR9JJ7BVBrAhtliUawxVdPYSdyl81taUYJ4C1mJ0iw2ueThE/qtr0J8B83tsIY8HJvh0lg5F+6ClK4xpA==",
       "requires": {
         "big-integer": "^1.6.48",
         "ejs": "^3.0.1",
@@ -1812,6 +1844,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "filelist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
+      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2764,8 +2804,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -3068,6 +3107,17 @@
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
+      }
+    },
+    "jake": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "js-sha3": {
@@ -3961,12 +4011,38 @@
       }
     },
     "r1csfile": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.5.tgz",
-      "integrity": "sha512-B+BdKPb/WUTp4N/3X4d1Spgx9Ojx5tFVejGZRJxpTtzq34mC8Vi/czWfiPj85V8kud31lCfYcZ16z7+czvM0Sw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.14.tgz",
+      "integrity": "sha512-7m4eWpnbjkwGGUaRmIAJc4w+HvaeBPJXUKHIqLkHeD9Yyjem6/EHmlgDVl+4hWNWGZqdhXuMqWSH9+O6QOXBdw==",
       "requires": {
-        "fastfile": "0.0.1",
-        "ffjavascript": "0.1.0"
+        "fastfile": "0.0.7",
+        "ffjavascript": "0.2.4"
+      },
+      "dependencies": {
+        "fastfile": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.7.tgz",
+          "integrity": "sha512-Zk7sdqsV6DsN/rhjULDfCCowPiMDsziTMFicdkrKN80yybr/6YFf9H91ELXN85dVEf6EYkVR5EHkZNc0dMqZKA=="
+        },
+        "ffjavascript": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.4.tgz",
+          "integrity": "sha512-XFeWcjUDFPavN+DDOxhE8p5MOhZQJc9oO1Sj4ml1pyjqNhS1ujEamcjFyK0cctdnat61i7lvpTYzdtS3RYDC8w==",
+          "requires": {
+            "big-integer": "^1.6.48",
+            "wasmcurves": "0.0.4",
+            "worker-threads": "^1.0.0"
+          }
+        },
+        "wasmcurves": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.4.tgz",
+          "integrity": "sha512-c/Tob+F/7jJhep1b2qtj54r4nkGaRifNbQ1OJx8cBBFH1RlHbWIbISHWONClOxiVwy/JZOpbN4SgvSX/4lF80A==",
+          "requires": {
+            "big-integer": "^1.6.42",
+            "blakejs": "^1.1.0"
+          }
+        }
       }
     },
     "randombytes": {
@@ -4467,7 +4543,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -4642,9 +4717,9 @@
       }
     },
     "tmp-promise": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
-      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.1.1.tgz",
+      "integrity": "sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==",
       "requires": {
         "tmp": "0.1.0"
       }
@@ -4845,6 +4920,15 @@
       "integrity": "sha512-zQSvZ7d74d9OvN+mCN6ucNne4QS5/cBBYTHldX0Oe+u9gStY21orapvuX1ajisA7RVIpuFhYg+ZgdySsPfeh0A==",
       "requires": {
         "big-integer": "^1.6.48"
+      }
+    },
+    "wasmcurves": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.5.tgz",
+      "integrity": "sha512-BmI4GXLjLawGg2YkvHa8zRsnWec+d1uwoxE+Iov8cqOpDL7GA5XO2pk2yuDbXHMzwIug2exnKot3baRZ86R0pA==",
+      "requires": {
+        "big-integer": "^1.6.42",
+        "blakejs": "^1.1.0"
       }
     },
     "web3": {
@@ -5204,6 +5288,11 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "worker-threads": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/worker-threads/-/worker-threads-1.0.0.tgz",
+      "integrity": "sha512-vK6Hhvph8oLxocEJIlc3YfGAZhm210uGzjZsXSu+JYLAQ/s/w4Tqgl60JrdH58hW8NSGP4m3bp8a92qPXgX05w=="
+    },
     "wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -5312,9 +5401,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -5326,7 +5415,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.1"
+        "yargs-parser": "^18.1.2"
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "blake-hash": "^1.1.0",
     "blake2b": "^2.1.3",
-    "circom": "0.5.10",
+    "circom": "0.5.21",
     "ffjavascript": "0.1.0",
     "web3": "^1.2.6"
   },


### PR DESCRIPTION
`LessThan` at the moment uses `Num2Bits(2*n+1)`, while it practically needs just an extra bit, so it could use `n+1` (h/t @jbaylina for noticing that). This is true because the inputs are assumed to be less than or equal to `n` bits, and so the difference of `a` and `b` + `2^n`, if `a < b`, will have the `n+1` bit off, which is what we check. 

Additionally, `n` must be `<= 252`, since `Num2Bits` can have multiple correct witnesses for `num bits >= 254`.