### PR TITLE
fix smt update

### DIFF
--- a/src/smt.js
+++ b/src/smt.js
@@ -58,10 +58,10 @@ class SMT {
 
         res.newRoot = rtNew;
 
+        await this.db.multiDel(dels);
         await this.db.multiIns(ins);
         await this.db.setRoot(rtNew);
         this.root = rtNew;
-        await this.db.multiDel(dels);
 
         return res;
     }

--- a/test/smtjs.js
+++ b/test/smtjs.js
@@ -161,4 +161,13 @@ describe("SMT Javascript test", function () {
         assert(Fr.eq(tree1.root, tree2.root));
     });
 
+    it("Should test update with same key-value", async () => {
+        const tree1 = await smt.newMemEmptyTrie();
+
+        await tree1.insert(8,88);
+        await tree1.update(8,88);
+
+        const res = await tree1.db.get(tree1.root);
+        assert.notEqual(res, undefined);
+    });
 });


### PR DESCRIPTION
## Issue
- smt `update` functionality performs first `inserts` and then `deletes` to the database.  
- If the `update` is done with the same key-value pair, it will delete the entry for the current root since it is the same database entry as the old root.

## fix approach
Perform first `deletes` and then `inserts` on smt `update` functionality.
Test has been added to ensure that root database entry is not deleted.