### PR TITLE
pass fixes size array arg in solidity poseidon implementation

### DIFF
--- a/src/poseidon_gencontract.js
+++ b/src/poseidon_gencontract.js
@@ -100,8 +100,13 @@ function createCode(nInputs) {
     C.push(0);
     C.calldataload();
     C.div();
-    C.push(Web3Utils.keccak256(`poseidon(uint256[${nInputs}])`).slice(0, 10)); // poseidon(uint256[])
+    C.dup(0);
+    C.push(Web3Utils.keccak256(`poseidon(uint256[${nInputs}])`).slice(0, 10)); // poseidon(uint256[n])
     C.eq();
+    C.swap(1);
+    C.push(Web3Utils.keccak256(`poseidon(bytes32[${nInputs}])`).slice(0, 10)); // poseidon(bytes32[n])
+    C.eq();
+    C.or();
     C.jmpi("start");
     C.invalid();
 
@@ -157,6 +162,27 @@ function createCode(nInputs) {
 
 function generateABI(nInputs) {
     return [
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": `bytes32[${nInputs}]`,
+                    "name": "input",
+                    "type": `bytes32[${nInputs}]`
+                }
+            ],
+            "name": "poseidon",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function"
+        },
         {
             "constant": true,
             "inputs": [

--- a/test/poseidoncontract.js
+++ b/test/poseidoncontract.js
@@ -21,15 +21,16 @@ describe("Poseidon Smart contract test", function () {
     });
 
     it("Should deploy the contract", async () => {
-        const C = new web3.eth.Contract(poseidonGenContract.abi);
+        const C6 = new web3.eth.Contract(poseidonGenContract.generateABI(5));
+        const C3 = new web3.eth.Contract(poseidonGenContract.generateABI(2));
 
-        poseidon6 = await C.deploy({
+        poseidon6 = await C6.deploy({
             data: poseidonGenContract.createCode(5)
         }).send({
             gas: 5000000,
             from: accounts[0]
         });
-        poseidon3 = await C.deploy({
+        poseidon3 = await C3.deploy({
             data: poseidonGenContract.createCode(2)
         }).send({
             gas: 5000000,
@@ -37,7 +38,7 @@ describe("Poseidon Smart contract test", function () {
         });
     });
 
-    it("Shold calculate the poseidon correctly t=6", async () => {
+    it("Should calculate the poseidon correctly t=6", async () => {
 
         const res = await poseidon6.methods.poseidon([1,2, 0, 0, 0]).call();
 
@@ -48,7 +49,7 @@ describe("Poseidon Smart contract test", function () {
 
         assert.equal(res.toString(), res2.toString());
     });
-    it("Shold calculate the poseidon correctly t=3", async () => {
+    it("Should calculate the poseidon correctly t=3", async () => {
 
         const res = await poseidon3.methods.poseidon([1,2]).call();
 


### PR DESCRIPTION
**Important** This is a breaking change. Now `poseidon_gencontract.js` does not export `abi`. The module exports the` generateABI` method to generate the ABI for a fixed count of elements of the input array. 

Passing fixed-size array to the hash is more safe and efficient.

Signature before 
```solidity
poseidon(uint256[] input) pure returns(uint256)
```

Signature after (an example for 3 inputs)
```solidity
poseidon(uint256[3] input) pure returns(uint256)
```

UPDATE:
poseidon contract now accepts both selectors: for uint256[n] and bytes32[n]