### PR TITLE
Update `mix` to match reference implementation ver

### DIFF
--- a/circuits/poseidon.circom
+++ b/circuits/poseidon.circom
@@ -30,7 +30,7 @@ template Mix(t, M) {
     for (var i=0; i<t; i++) {
         lc = 0;
         for (var j=0; j<t; j++) {
-            lc += M[j][i]*in[j];
+            lc += M[i][j]*in[j];
         }
         out[i] <== lc;
     }

--- a/src/poseidon.js
+++ b/src/poseidon.js
@@ -39,7 +39,7 @@ function poseidon(inputs) {
         // no matrix multiplication in the last round
         if (r < nRoundsF + nRoundsP - 1) {
             state = state.map((_, i) =>
-                state.reduce((acc, a, j) => F.add(acc, F.mul(M[t - 2][j][i], a)), F.zero)
+                state.reduce((acc, a, j) => F.add(acc, F.mul(M[t - 2][i][j], a)), F.zero)
             );
         }
     }

--- a/src/poseidon_gencontract.js
+++ b/src/poseidon_gencontract.js
@@ -29,7 +29,7 @@ function createCode(nInputs) {
     function saveM() {
         for (let i=0; i<t; i++) {
             for (let j=0; j<t; j++) {
-                C.push(toHex256(M[t-2][j][i]));
+                C.push(toHex256(M[t-2][i][j]));
                 C.push((1+i*t+j)*32);
                 C.mstore();
             }

--- a/test/eddsa_js.js
+++ b/test/eddsa_js.js
@@ -67,12 +67,12 @@ describe("EdDSA js test", function () {
         assert.equal(signature.R8[1].toString(),
             "15383486972088797283337779941324724402501462225528836549661220478783371668959");
         assert.equal(signature.S.toString(),
-            "1398758333392199195742243841591064350253744445503462896781493968760929513778");
+            "938949321795232811108166733391487122595698117244126885899082887611217406272");
 
         const pSignature = eddsa.packSignature(signature);
         assert.equal(pSignature.toString("hex"), ""+
             "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
-            "32f16b0f2f4c4e1169aa59685637e1429b6581a9531d058d65f4ab224eab1703");
+            "40e930f04ce3a13bdca883639e77d1a0cd52b5ed0666df8a201df1fe2d6d1302");
 
         const uSignature = eddsa.unpackSignature(pSignature);
         assert(eddsa.verifyPoseidon(msg, uSignature, pubKey));

--- a/test/poseidoncircuit.js
+++ b/test/poseidoncircuit.js
@@ -21,7 +21,7 @@ describe("Poseidon Circuit test", function () {
         const w = await circuit6.calculateWitness({inputs: [1, 2, 0,0,0]}, true);
 
         const res2 = poseidon([1,2,0,0,0]);
-        assert.equal("3975478831357328722254985704342968745327876719981393787143845259590563829094", res2.toString());
+        assert.equal("1944517543886089121158331594914426541694339782056411886233994349799551050705", res2.toString());
         await circuit6.assertOut(w, {out : res2});
         await circuit6.checkConstraints(w);
     });
@@ -31,7 +31,7 @@ describe("Poseidon Circuit test", function () {
 
         const res2 = poseidon([3, 4,5,10,23]);
 
-        assert.equal("18540626624821144952552691894137986276337186174352554475896834101336254024067", res2.toString());
+        assert.equal("15043529598202765311255531083507141602555136943545139099151157943137780370931", res2.toString());
         await circuit6.assertOut(w, {out : res2});
         await circuit6.checkConstraints(w);
     });
@@ -41,7 +41,7 @@ describe("Poseidon Circuit test", function () {
         const w = await circuit3.calculateWitness({inputs: [1, 2]});
 
         const res2 = poseidon([1,2]);
-        assert.equal("17117985411748610629288516079940078114952304104811071254131751175361957805920", res2.toString());
+        assert.equal("11309872961022349216464221841186646423561022368884850929991258903497301047946", res2.toString());
         await circuit3.assertOut(w, {out : res2});
         await circuit3.checkConstraints(w);
     });
@@ -50,7 +50,7 @@ describe("Poseidon Circuit test", function () {
         const w = await circuit3.calculateWitness({inputs: [3, 4]});
 
         const res2 = poseidon([3, 4]);
-        assert.equal("21867347236198497199818917118739170715216974132230970409806500217655788551452", res2.toString());
+        assert.equal("5452722186384045185233705092171776011224530037417547968760104202263491217182", res2.toString());
         await circuit3.assertOut(w, {out : res2});
         await circuit3.checkConstraints(w);
     });


### PR DESCRIPTION
Reference implementation: https://extgit.iaik.tugraz.at/krypto/hadeshash

Tested with `sage code/poseidonperm_x5_254_3.sage` for inputs:
`[1,2,0]`, equivalent to using `circomlib/poseidon.js` with inputs
`[1,2]`, both return as result
`11309872961022349216464221841186646423561022368884850929991258903497301047946`

Tested with `sage code/poseidonperm_x5_254_5.sage` for inputs:
`[1,2,3,4,0]`, equivalent to using `circomlib/poseidon.js` with inputs
`[1,2,3,4]`, both return as result
`18181515143627462196415302348515936346022476168236332098176009127325427112991`