### PR TITLE
Fix the input length check for the Poseidon EVM implementation

### DIFF
--- a/src/poseidon_gencontract.js
+++ b/src/poseidon_gencontract.js
@@ -19,7 +19,7 @@ function toHex256(a) {
 
 function createCode(nInputs) {
 
-    if (( nInputs<1) || (nInputs>8)) throw new Error("Invalid number of inputs. Must be 1<=nInputs<=8");
+    if (( nInputs<1) || (nInputs>6)) throw new Error("Invalid number of inputs. Must be 1<=nInputs<=6");
     const t = nInputs + 1;
     const nRoundsF = N_ROUNDS_F;
     const nRoundsP = N_ROUNDS_P[t - 2];


### PR DESCRIPTION
The `createCode()` function in `poseidon_gencontract.js` supports up to 6 inputs, as any value above that will throw an error:

```
$ node
Welcome to Node.js v15.8.0.
Type ".help" for more information.
> g = require('./src/poseidon_gencontract.js')
{
  generateABI: [Function: generateABI],
  createCode: [Function: createCode]
}
> a = g.createCode(7)

Uncaught Error: Assertion failed
    at Contract.dup (/home/user/circomlib/src/evmasm.js:177:19)
    at mix (/home/user/circomlib/src/poseidon_gencontract.js:82:23)
    at Object.createCode (/home/user/circomlib/src/poseidon_gencontract.js:153:5)
```

This PR changes the assertion statement to check that the user has provided no more than 6 inputs and no less than 1 inputs.