### PR TITLE
Extend accepted number of Poseidon inputs to 16 in JS

### DIFF
--- a/src/poseidon.js
+++ b/src/poseidon.js
@@ -20,7 +20,7 @@ const pow5 = a => F.mul(a, F.square(F.square(a, a)));
 
 function poseidon(inputs) {
     assert(inputs.length > 0);
-    assert(inputs.length < N_ROUNDS_P.length - 1);
+    assert(inputs.length <= N_ROUNDS_P.length);
 
     const t = inputs.length + 1;
     const nRoundsF = N_ROUNDS_F;

--- a/test/circuits/poseidon16_test.circom
+++ b/test/circuits/poseidon16_test.circom
@@ -1,0 +1,3 @@
+include "../../circuits/poseidon.circom"
+
+component main = Poseidon(16);

--- a/test/poseidoncircuit.js
+++ b/test/poseidoncircuit.js
@@ -9,12 +9,14 @@ const assert = chai.assert;
 describe("Poseidon Circuit test", function () {
     let circuit6;
     let circuit3;
+    let circuit16;
 
     this.timeout(100000);
 
     before( async () => {
         circuit6 = await tester(path.join(__dirname, "circuits", "poseidon6_test.circom"));
         circuit3 = await tester(path.join(__dirname, "circuits", "poseidon3_test.circom"));
+        circuit16 = await tester(path.join(__dirname, "circuits", "poseidon16_test.circom"));
     });
 
     it("Should check constrain of hash([1, 2]) t=6", async () => {
@@ -56,5 +58,15 @@ describe("Poseidon Circuit test", function () {
         assert.equal("14763215145315200506921711489642608356394854266165572616578112107564877678998", res2.toString());
         await circuit3.assertOut(w, {out : res2});
         await circuit3.checkConstraints(w);
+    });
+
+    it("Should check constrain of hash([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16])", async () => {
+        const w = await circuit16.calculateWitness({inputs: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]});
+
+        const res2 = poseidon([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+
+        assert.equal("9989051620750914585850546081941653841776809718687451684622678807385399211877", res2.toString());
+        await circuit16.assertOut(w, {out : res2});
+        await circuit16.checkConstraints(w);
     });
 });

--- a/test/poseidonjs.js
+++ b/test/poseidonjs.js
@@ -3,7 +3,7 @@ const assert = chai.assert;
 
 const poseidon = require("../src/poseidon.js");
 
-describe("Poseidon Circuit test", function () {
+describe("Poseidon js test", function () {
     it("Should check constrain reference implementation poseidonperm_x5_254_3", async () => {
         const res2 = poseidon([1,2]);
         assert.equal("115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a", res2.toString(16));
@@ -11,5 +11,9 @@ describe("Poseidon Circuit test", function () {
     it("Should check constrain reference implementation poseidonperm_x5_254_5", async () => {
         const res2 = poseidon([1,2,3,4]);
         assert.equal("299c867db6c1fdd79dcefa40e4510b9837e60ebb1ce0663dbaa525df65250465", res2.toString(16));
+    });
+    it("Should check poseidon with 16 inputs", async () => {
+        const res2 = poseidon([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+        assert.equal("9989051620750914585850546081941653841776809718687451684622678807385399211877", res2.toString(10));
     });
 });


### PR DESCRIPTION
Extend accepted number of Poseidon inputs to 16 in JS.
Added test vector to js and circuit implementation.