### PR TITLE
Mux6 template

### DIFF
--- a/circuits/mux6.circom
+++ b/circuits/mux6.circom
@@ -1,0 +1,82 @@
+/*
+    Copyright 2018 0KIMS association.
+
+    This file is part of circom (Zero Knowledge Circuit Compiler).
+
+    circom is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    circom is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with circom. If not, see <https://www.gnu.org/licenses/>.
+*/
+pragma circom 2.0.0;
+
+include "mux3.circom";
+
+template MultiMux6(n) {
+    signal input c[n][64];  // Constants
+    signal input s[6];   // Selector
+    signal output out[n];
+
+    component leafs[n][8];
+    component root[n];
+    for (var i=0; i<n; i++) {
+        // Make a tree (with depth 2) of Mux3 components, with 8 leaf node and one root node.
+
+        // Leaf components
+        for (var j=0; j<8; j++) {
+            leafs[i][j] = MultiMux3(n);
+
+            // Set the leaf component's constants
+            for (var k=0; k<8; k++) {
+                leafs[i][j].c[i][k] <== c[i][8 * j + k];
+            }
+
+            // Set the leaf component's selector (the least significant 3 bits of the selector);
+            leafs[i][j].s[0] <== s[0];
+            leafs[i][j].s[1] <== s[1];
+            leafs[i][j].s[2] <== s[2];
+        }
+
+        // Root component
+        root[i] = Mux3();
+
+        // Set the root component's constants (the output of it's child nodes).
+        for (var j=0; j<8; j++) {
+            root[i].c[j] <== leafs[i][j].out[i];
+        }
+
+        // Set the root component's selector (the most significant 3 bits of the selector);
+        root[i].s[0] <== s[3];
+        root[i].s[1] <== s[4];
+        root[i].s[2] <== s[5];
+
+        out[i] <== root[i].out;
+    }
+}
+
+template Mux6() {
+    var i;
+    signal input c[64];  // Constants
+    signal input s[6];   // Selector
+    signal output out;
+
+    component mux = MultiMux6(1);
+
+    for (i=0; i<64; i++) {
+        mux.c[0][i] <== c[i];
+    }
+
+    for (i=0; i<6; i++) {
+      s[i] ==> mux.s[i];
+    }
+
+    mux.out[0] ==> out;
+}

--- a/test/circuits/mux6_1.circom
+++ b/test/circuits/mux6_1.circom
@@ -1,0 +1,100 @@
+pragma circom 2.0.0;
+
+include "../../circuits/mux6.circom";
+include "../../circuits/bitify.circom";
+
+
+template Constants() {
+    var i;
+    signal output out[64];
+
+    out[0] <== 1230;
+    out[1] <== 4560;
+    out[2] <== 7890;
+    out[3] <== 0120;
+    out[4] <== 1110;
+    out[5] <== 2220;
+    out[6] <== 3330;
+    out[7] <== 45460;
+    out[8] <== 1345230;
+    out[9] <== 443560;
+    out[10] <== 156230;
+    out[11] <== 45660;
+    out[12] <== 12230;
+    out[13] <== 45460;
+    out[14] <== 42560;
+    out[15] <== 44560;
+
+    out[16] <== 1231;
+    out[17] <== 4561;
+    out[18] <== 7891;
+    out[19] <== 0121;
+    out[20] <== 1111;
+    out[21] <== 2221;
+    out[22] <== 3331;
+    out[23] <== 45461;
+    out[24] <== 1345231;
+    out[25] <== 443561;
+    out[26] <== 156231;
+    out[27] <== 45661;
+    out[28] <== 12231;
+    out[29] <== 45461;
+    out[30] <== 42561;
+    out[31] <== 44561;
+
+    out[32] <== 1232;
+    out[33] <== 4562;
+    out[34] <== 7892;
+    out[35] <== 0122;
+    out[36] <== 1112;
+    out[37] <== 2222;
+    out[38] <== 3332;
+    out[39] <== 45462;
+    out[40] <== 1345232;
+    out[41] <== 443562;
+    out[42] <== 156232;
+    out[43] <== 45662;
+    out[44] <== 12232;
+    out[45] <== 45462;
+    out[46] <== 42562;
+    out[47] <== 44562;
+
+    out[48] <== 1233;
+    out[49] <== 4563;
+    out[50] <== 7893;
+    out[51] <== 0123;
+    out[52] <== 1113;
+    out[53] <== 2223;
+    out[54] <== 3333;
+    out[55] <== 45463;
+    out[56] <== 1345233;
+    out[57] <== 443563;
+    out[58] <== 156233;
+    out[59] <== 45663;
+    out[60] <== 12233;
+    out[61] <== 45463;
+    out[62] <== 42563;
+    out[63] <== 44563;
+}
+
+template Main() {
+    var i;
+    signal input selector;//private
+    signal output out;
+
+    component mux = Mux6();
+    component n2b = Num2Bits(6);
+    component cst = Constants();
+
+    selector ==> n2b.in;
+    for (i=0; i<6; i++) {
+        n2b.out[i] ==> mux.s[i];
+    }
+    for (i=0; i<64; i++) {
+        cst.out[i] ==> mux.c[i];
+    }
+
+    mux.out ==> out;
+}
+
+component main = Main();

--- a/test/escalarmul.js
+++ b/test/escalarmul.js
@@ -11,7 +11,7 @@ function print(circuit, w, s) {
     console.log(s + ": " + w[circuit.getSignalIdx(s)]);
 }
 
-describe("Exponentioation test", function () {
+describe("Exponentiation test", function () {
     let babyJub;
     let Fr;
     this.timeout(100000);

--- a/test/multiplexer.js
+++ b/test/multiplexer.js
@@ -5,8 +5,91 @@ const Scalar = require("ffjavascript").Scalar;
 exports.p = Scalar.fromString("21888242871839275222246405745257275088548364400416034343698204186575808495617");
 const Fr = new F1Field(exports.p);
 
-describe("Mux4 test", function() {
+describe("Mux6 test", function() {
     this.timeout(100000);
+    it("Should create a constant multiplexer 6", async () => {
+
+        const circuit = await wasm_tester(path.join(__dirname, "circuits", "mux6_1.circom"));
+
+        const ct64 = [
+            Fr.e("1230"),
+            Fr.e("4560"),
+            Fr.e("7890"),
+            Fr.e("0120"),
+            Fr.e("1110"),
+            Fr.e("2220"),
+            Fr.e("3330"),
+            Fr.e("45460"),
+            Fr.e("1345230"),
+            Fr.e("443560"),
+            Fr.e("156230"),
+            Fr.e("45660"),
+            Fr.e("12230"),
+            Fr.e("45460"),
+            Fr.e("42560"),
+            Fr.e("44560"),
+
+            Fr.e("1231"),
+            Fr.e("4561"),
+            Fr.e("7891"),
+            Fr.e("0121"),
+            Fr.e("1111"),
+            Fr.e("2221"),
+            Fr.e("3331"),
+            Fr.e("45461"),
+            Fr.e("1345231"),
+            Fr.e("443561"),
+            Fr.e("156231"),
+            Fr.e("45661"),
+            Fr.e("12231"),
+            Fr.e("45461"),
+            Fr.e("42561"),
+            Fr.e("44561"),
+
+            Fr.e("1232"),
+            Fr.e("4562"),
+            Fr.e("7892"),
+            Fr.e("0122"),
+            Fr.e("1112"),
+            Fr.e("2222"),
+            Fr.e("3332"),
+            Fr.e("45462"),
+            Fr.e("1345232"),
+            Fr.e("443562"),
+            Fr.e("156232"),
+            Fr.e("45662"),
+            Fr.e("12232"),
+            Fr.e("45462"),
+            Fr.e("42562"),
+            Fr.e("44562"),
+
+	    Fr.e("1233"),
+            Fr.e("4563"),
+            Fr.e("7893"),
+            Fr.e("0123"),
+            Fr.e("1113"),
+            Fr.e("2223"),
+            Fr.e("3333"),
+            Fr.e("45463"),
+            Fr.e("1345233"),
+            Fr.e("443563"),
+            Fr.e("156233"),
+            Fr.e("45663"),
+            Fr.e("12233"),
+            Fr.e("45463"),
+            Fr.e("42563"),
+            Fr.e("44563")
+        ];
+
+        for (let i=0; i<64; i++) {
+            const w = await circuit.calculateWitness({ "selector": i }, true);
+
+            await circuit.checkConstraints(w);
+
+            await circuit.assertOut(w, {out: ct64[i]});
+        }
+    });
+
     it("Should create a constant multiplexer 4", async () => {
 
         const circuit = await wasm_tester(path.join(__dirname, "circuits", "mux4_1.circom"));


### PR DESCRIPTION
This PR adds the Mux6 template.

This template/component will accept a 6 bit selector and 64 constants, and output the appropriate constant.

It is a tree (of depth 2) of mux3 components.  The leaf components handle the selector's least significant 3 bits and the root component handles the most significant 3 bits.

I also added a test case for this new template.