### PR TITLE
fixes Decoder template adding missing check

### DIFF
--- a/circuits/multiplexer.circom
+++ b/circuits/multiplexer.circom
@@ -77,6 +77,13 @@ template EscalarProduct(w) {
     out <== lc;
 }
 
+// in case inp >= w then witness = 0, in other case witness = 1, out[i] = 1 if i = inp and 0 otherwise
+/* 
+Specification:
+  - Success := w < inp
+  - for i in 0..w: out[i] = 1 if i = inp, else out[i] = 0 
+*/
+
 template Decoder(w) {
     signal input inp;
     signal output out[w];
@@ -95,12 +102,34 @@ template Decoder(w) {
     lc ==> success;
 }
 
+// in case inp >= w does not accept any solution -> does not generate witness
+/* 
+Specification:
+  In case inp < w:
+     - for i in 0..w: out[i] = 1 if i = inp, else out[i] = 0 
+  If w >= inp => the sysetm of constraints does not have any solution
+*/
+template Decoder_strict(w) {
+    signal input inp;
+    signal output out[w];
+    var lc=0;
+
+    for (var i=0; i<w; i++) {
+        out[i] <-- (inp == i) ? 1 : 0;
+        out[i] * (inp-i) === 0;
+        lc = lc + out[i];
+    }
+
+    lc === 1;
+}
+
+
 
 template Multiplexer(wIn, nIn) {
     signal input inp[nIn][wIn];
     signal input sel;
     signal output out[wIn];
-    component dec = Decoder(nIn);
+    component dec = Decoder_strict(nIn);
     component ep[wIn];
 
     for (var k=0; k<wIn; k++) {
@@ -115,5 +144,5 @@ template Multiplexer(wIn, nIn) {
         }
         ep[j].out ==> out[j];
     }
-    dec.success === 1;
 }
+

--- a/circuits/multiplexer.circom
+++ b/circuits/multiplexer.circom
@@ -62,6 +62,8 @@ function log2(a) {
 
 pragma circom 2.0.0;
 
+include "comparators.circom";
+
 template EscalarProduct(w) {
     signal input in1[w];
     signal input in2[w];
@@ -80,15 +82,17 @@ template Decoder(w) {
     signal output out[w];
     signal output success;
     var lc=0;
+    
+    component checkZero[w];
 
     for (var i=0; i<w; i++) {
-        out[i] <-- (inp == i) ? 1 : 0;
-        out[i] * (inp-i) === 0;
+        checkZero[i] = IsZero();
+        checkZero[i].in <== inp - i;
+        out[i] <== checkZero[i].out;
         lc = lc + out[i];
     }
 
     lc ==> success;
-    success * (success -1) === 0;
 }
 
 


### PR DESCRIPTION
The Decoder template misses a check, generating a R1CS constraint system that admits multiple outputs for the same input. For example, in case it is instantiated with w = 2 then the generated constraint system
```
out[0] * inp === 0
out[1] * (inp - 1) === 0
out[0] + out[1] === success
success * (success - 1) === 0
```
admits multiple solutions for the input inp = 1:

- out[0] === 0, out[1] === 1, success = 1
- out[0] === 0, out[1] === 0, success = 0 

The proposed solution adds the missing check satisfying the same specification for the template.
  - Success := w < inp
  - for i in 0..w: out[i] = 1 if i = inp, else out[i]

 However, as adding the check increments the number of non-linear constraints, the proposed solution also defines a new template (Decoder_strict) that can be used to optimize the number of non-linear constraints when the only solutions that are valid are the ones where success == 1. This condition appears in the template Multiplexer that represents the main use of Decoder in the circomlib. 

The template Decoder_strict satisfies the following specification:
  - In case inp < w:
         for i in 0..w: out[i] = 1 if i = inp, else out[i] = 0 
 -  If w >= inp => the sysetm of constraints does not have any solution

The number of constraints after compiling using --O2 of each one of the templates is:
- Decoder(w): 2 * w + 1
- Decoder_strict(w): w + 1
- Multiplexer(wIn, nIn): (wIn + 1) * nIn (same as previous version of Multiplexer)