### PR TITLE
add `SafeLessThan` template to comparators with range proofs over inputs

### DIFF
--- a/circuits/comparators.circom
+++ b/circuits/comparators.circom
@@ -98,6 +98,23 @@ template LessThan(n) {
     out <== 1-n2b.out[n];
 }
 
+// Do Range checks on the inputs to avoid overflow
+template SafeLessThan(n) {
+    assert(n <= 252);
+    signal input in[2];
+    signal output out;
+
+    component aInRange = Num2Bits(252);
+    aInRange.in <== in[0];
+    component bInRange = Num2Bits(252);
+    bInRange.in <== in[1];
+
+    component n2b = Num2Bits(n+1);
+
+    n2b.in <== in[0]+ (1<<n) - in[1];
+
+    out <== 1-n2b.out[n];
+}
 
 
 // N is the number of bits the input  have.


### PR DESCRIPTION
@BlakeMScurr recently spotted an anomalous behavior in the `LessThan(n)` template when the first input doesn't fit in n bits. This issue was discussed [in Sismo](https://github.com/sismo-core/hydra-s1-zkps/issues/8), [Iden3](https://github.com/iden3/circuits/pull/40) and fully analysed and tested [by Blake](https://github.com/BlakeMScurr/comparator-overflow).

After discussing with Blake and @clararod9 we propose a `SafeLessThan(n)` template that uses `Num2Bits(252)` to 
perform a range check over the two inputs. As long as both the inputs don't overflow 252 bits, the operation is safe.

Performing `SafeLessThan(n)` adds 252*2 constraints compared to LessThan(n) therefore, it should be used either if the range check over the inputs has already been performed outside the template or the inputs are not expected to overflow 252 bits.