### PR TITLE
Bump up circom_tester version to 0.0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "blake-hash": "^2.0.0",
         "chai": "^4.3.4",
-        "circom_tester": "0.0.13",
+        "circom_tester": "0.0.19",
         "circomlibjs": "^0.1.4",
         "mocha": "^9.1.3"
       }
@@ -841,13 +841,19 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "dev": true
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+    "node_modules/bfj": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
       "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "check-types": "^11.1.1",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      },
       "engines": {
-        "node": ">=0.6"
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -894,10 +900,10 @@
         "nanoassert": "^2.0.0"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "node_modules/bn.js": {
@@ -1020,6 +1026,12 @@
         "node": "*"
       }
     },
+    "node_modules/check-types": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.2.tgz",
+      "integrity": "sha512-HBiYvXvn9Z70Z88XKjz3AEKd4HJhBXsa3j7xFnITAzoS8+q6eIGi8qDB8FKPBAjtuxjI/zFpwuiCb8oDtKOYrA==",
+      "dev": true
+    },
     "node_modules/child_process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
@@ -1054,52 +1066,41 @@
       }
     },
     "node_modules/circom_runtime": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.14.tgz",
-      "integrity": "sha512-MLbHHZVkYuWyZiYErLmT5y0qbTRXDD1NhaDyLhQNF0JCb6brx8r/VJDevwne7sT1re7qHpHCQAL5rhqByQ7obQ==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
+      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
       "dev": true,
       "dependencies": {
-        "ffjavascript": "0.2.39",
-        "fnv-plus": "^1.3.1"
+        "ffjavascript": "0.2.56"
       },
       "bin": {
         "calcwit": "calcwit.js"
       }
     },
     "node_modules/circom_runtime/node_modules/ffjavascript": {
-      "version": "0.2.39",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.39.tgz",
-      "integrity": "sha512-9ewb5keKHL1owKTxCK7sDuA34SPJxnznWqdJgwBW51moCvg+wf9L0W5mcxm8qMUxt2OE/KjBQUKmYLaKyNNrPw==",
+      "version": "0.2.56",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
       "dev": true,
       "dependencies": {
-        "big-integer": "^1.6.48",
-        "wasmcurves": "0.0.14",
-        "web-worker": "^1.0.0"
-      }
-    },
-    "node_modules/circom_runtime/node_modules/wasmcurves": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.14.tgz",
-      "integrity": "sha512-G1iMkxlRaQSdqQ1JrwHcU+awLmwyH6kFKfT8g9obd8MWe+u5oSdFXrODB0zmSI5aGGvJPG+4cAmqCGYv9R+7qg==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.42",
-        "blakejs": "^1.1.0"
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/circom_tester": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.13.tgz",
-      "integrity": "sha512-VV6SeU28wGouPRKdcoHYAmbtVCW3pXW1nuFRmpn+7xakeNKuHDw6ECK7LDeBdJw3s9I5hwxQkkw5J9Letxt6hg==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.19.tgz",
+      "integrity": "sha512-SNHaBsGxcBH6XsVWfsRbRPA7NF8m8AMKJI9dtJJCFGUtOTT2+zsoIqAwi50z6XCnO4TtjyXq7AeXa1PLHqT0tw==",
       "dev": true,
       "dependencies": {
-        "chai": "^4.3.4",
+        "chai": "^4.3.6",
         "child_process": "^1.0.2",
-        "ffjavascript": "^0.2.38",
+        "ffjavascript": "^0.2.56",
         "fnv-plus": "^1.3.1",
-        "r1csfile": "0.0.37",
-        "snarkjs": "0.4.10",
-        "tmp-promise": "^3.0.2",
+        "r1csfile": "^0.0.41",
+        "snarkjs": "0.5.0",
+        "tmp-promise": "^3.0.3",
         "util": "^0.12.4"
       }
     },
@@ -1394,14 +1395,13 @@
       "dev": true
     },
     "node_modules/ffjavascript": {
-      "version": "0.2.55",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.55.tgz",
-      "integrity": "sha512-8X0FCIPOWiK6DTWh3pnE3O6D6nIQsirStAXpWMzRDnoDX7SEnDX4I28aVhwjL7L35XS1vy2AU7zc0UCGYxdLjw==",
+      "version": "0.2.57",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+      "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
       "dev": true,
       "dependencies": {
-        "big-integer": "^1.6.48",
-        "wasmbuilder": "^0.0.12",
-        "wasmcurves": "0.1.0",
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
         "web-worker": "^1.2.0"
       }
     },
@@ -1424,9 +1424,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1738,6 +1738,15 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/inflight": {
@@ -2376,15 +2385,26 @@
       }
     },
     "node_modules/r1csfile": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.37.tgz",
-      "integrity": "sha512-6Yb2SqWU59t7wWUX0/4BvVtWAN7RwkIobFJ90+RD3MB2Y5gb5aBGkFWJxDLqqWQbmQnv3y0ekpfDxbtNNAgrGw==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
+      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
       "dev": true,
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.11",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.55"
+        "ffjavascript": "0.2.56"
+      }
+    },
+    "node_modules/r1csfile/node_modules/ffjavascript": {
+      "version": "0.2.56",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "dev": true,
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/randombytes": {
@@ -2421,12 +2441,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/readline": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
-      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -2519,73 +2533,35 @@
       }
     },
     "node_modules/snarkjs": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.4.10.tgz",
-      "integrity": "sha512-YWgxso7CGcSfkyDGraVjPuBJtq6GEsZ16YBJj2eD0TFum2D5BxnawvyTo4p/7UpctAT0r05DoHo80zgaWnbIKA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
+      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
       "dev": true,
       "dependencies": {
-        "@iden3/binfileutils": "0.0.8",
-        "blake2b-wasm": "^2.3.0",
-        "circom_runtime": "0.1.14",
+        "@iden3/binfileutils": "0.0.11",
+        "bfj": "^7.0.2",
+        "blake2b-wasm": "^2.4.0",
+        "circom_runtime": "0.1.21",
         "ejs": "^3.1.6",
-        "fastfile": "0.0.19",
-        "ffjavascript": "0.2.39",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.2.56",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.33",
-        "readline": "^1.3.0"
+        "r1csfile": "0.0.41"
       },
       "bin": {
         "snarkjs": "build/cli.cjs"
       }
     },
-    "node_modules/snarkjs/node_modules/@iden3/binfileutils": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.8.tgz",
-      "integrity": "sha512-/GqTsujUssGuQY+sd/XaLrA+OiCwzm+6yH28C57QQDWCHET2Logry9fGxU10n6XKdhCQBjZ7T/YMQkLwwkpRTQ==",
-      "dev": true,
-      "dependencies": {
-        "fastfile": "0.0.19",
-        "ffjavascript": "^0.2.30"
-      }
-    },
-    "node_modules/snarkjs/node_modules/fastfile": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.19.tgz",
-      "integrity": "sha512-tz9nWR5KYb6eR2odFQ7oxqEkx8F3YQZ6NBJoJR92YEG3DqYOqyxMck8PKvTVNKx3uwvOqGnLXNScnqpdHRdHGQ==",
-      "dev": true
-    },
     "node_modules/snarkjs/node_modules/ffjavascript": {
-      "version": "0.2.39",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.39.tgz",
-      "integrity": "sha512-9ewb5keKHL1owKTxCK7sDuA34SPJxnznWqdJgwBW51moCvg+wf9L0W5mcxm8qMUxt2OE/KjBQUKmYLaKyNNrPw==",
+      "version": "0.2.56",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
       "dev": true,
       "dependencies": {
-        "big-integer": "^1.6.48",
-        "wasmcurves": "0.0.14",
-        "web-worker": "^1.0.0"
-      }
-    },
-    "node_modules/snarkjs/node_modules/r1csfile": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.33.tgz",
-      "integrity": "sha512-aSZa/Vy6avJ146MOewUNRYdDLJCDINZ7aqSt0Zhw4uVrd4TijOz6gBfmckr7tPILaT3RNp7THVpUzeW0++OlJw==",
-      "dev": true,
-      "dependencies": {
-        "@iden3/bigarray": "0.0.2",
-        "@iden3/binfileutils": "0.0.8",
-        "fastfile": "0.0.19",
-        "ffjavascript": "0.2.39"
-      }
-    },
-    "node_modules/snarkjs/node_modules/wasmcurves": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.14.tgz",
-      "integrity": "sha512-G1iMkxlRaQSdqQ1JrwHcU+awLmwyH6kFKfT8g9obd8MWe+u5oSdFXrODB0zmSI5aGGvJPG+4cAmqCGYv9R+7qg==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.42",
-        "blakejs": "^1.1.0"
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -2711,6 +2687,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -2756,22 +2738,18 @@
       "dev": true
     },
     "node_modules/wasmbuilder": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.12.tgz",
-      "integrity": "sha512-dTMpBgrnLOXrN58i2zakn2ScynsBhq9LfyQIsPz4CyxRF9k1GAORniuqn3xmE9NnI1l7g3iiVCkoB2Cl0/oG8w==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.48"
-      }
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.16.tgz",
+      "integrity": "sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==",
+      "dev": true
     },
     "node_modules/wasmcurves": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.1.0.tgz",
-      "integrity": "sha512-kIlcgbVUAv2uQ6lGsepGz/m5V40+Z6rvTBkqCYn3Y2+OcXst+UaP4filJYLh/xDxjJl62FFjZZeAnpeli1Y5/Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
+      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
       "dev": true,
       "dependencies": {
-        "big-integer": "^1.6.42",
-        "blakejs": "^1.1.0"
+        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/web-worker": {
@@ -3447,11 +3425,17 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "dev": true
     },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "dev": true
+    "bfj": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "check-types": "^11.1.1",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -3490,10 +3474,10 @@
         "nanoassert": "^2.0.0"
       }
     },
-    "blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "bn.js": {
@@ -3591,6 +3575,12 @@
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
+    "check-types": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.2.tgz",
+      "integrity": "sha512-HBiYvXvn9Z70Z88XKjz3AEKd4HJhBXsa3j7xFnITAzoS8+q6eIGi8qDB8FKPBAjtuxjI/zFpwuiCb8oDtKOYrA==",
+      "dev": true
+    },
     "child_process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
@@ -3614,51 +3604,40 @@
       }
     },
     "circom_runtime": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.14.tgz",
-      "integrity": "sha512-MLbHHZVkYuWyZiYErLmT5y0qbTRXDD1NhaDyLhQNF0JCb6brx8r/VJDevwne7sT1re7qHpHCQAL5rhqByQ7obQ==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
+      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
       "dev": true,
       "requires": {
-        "ffjavascript": "0.2.39",
-        "fnv-plus": "^1.3.1"
+        "ffjavascript": "0.2.56"
       },
       "dependencies": {
         "ffjavascript": {
-          "version": "0.2.39",
-          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.39.tgz",
-          "integrity": "sha512-9ewb5keKHL1owKTxCK7sDuA34SPJxnznWqdJgwBW51moCvg+wf9L0W5mcxm8qMUxt2OE/KjBQUKmYLaKyNNrPw==",
+          "version": "0.2.56",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+          "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
           "dev": true,
           "requires": {
-            "big-integer": "^1.6.48",
-            "wasmcurves": "0.0.14",
-            "web-worker": "^1.0.0"
-          }
-        },
-        "wasmcurves": {
-          "version": "0.0.14",
-          "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.14.tgz",
-          "integrity": "sha512-G1iMkxlRaQSdqQ1JrwHcU+awLmwyH6kFKfT8g9obd8MWe+u5oSdFXrODB0zmSI5aGGvJPG+4cAmqCGYv9R+7qg==",
-          "dev": true,
-          "requires": {
-            "big-integer": "^1.6.42",
-            "blakejs": "^1.1.0"
+            "wasmbuilder": "0.0.16",
+            "wasmcurves": "0.2.0",
+            "web-worker": "^1.2.0"
           }
         }
       }
     },
     "circom_tester": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.13.tgz",
-      "integrity": "sha512-VV6SeU28wGouPRKdcoHYAmbtVCW3pXW1nuFRmpn+7xakeNKuHDw6ECK7LDeBdJw3s9I5hwxQkkw5J9Letxt6hg==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.19.tgz",
+      "integrity": "sha512-SNHaBsGxcBH6XsVWfsRbRPA7NF8m8AMKJI9dtJJCFGUtOTT2+zsoIqAwi50z6XCnO4TtjyXq7AeXa1PLHqT0tw==",
       "dev": true,
       "requires": {
-        "chai": "^4.3.4",
+        "chai": "^4.3.6",
         "child_process": "^1.0.2",
-        "ffjavascript": "^0.2.38",
+        "ffjavascript": "^0.2.56",
         "fnv-plus": "^1.3.1",
-        "r1csfile": "0.0.37",
-        "snarkjs": "0.4.10",
-        "tmp-promise": "^3.0.2",
+        "r1csfile": "^0.0.41",
+        "snarkjs": "0.5.0",
+        "tmp-promise": "^3.0.3",
         "util": "^0.12.4"
       }
     },
@@ -3891,14 +3870,13 @@
       "dev": true
     },
     "ffjavascript": {
-      "version": "0.2.55",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.55.tgz",
-      "integrity": "sha512-8X0FCIPOWiK6DTWh3pnE3O6D6nIQsirStAXpWMzRDnoDX7SEnDX4I28aVhwjL7L35XS1vy2AU7zc0UCGYxdLjw==",
+      "version": "0.2.57",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+      "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
       "dev": true,
       "requires": {
-        "big-integer": "^1.6.48",
-        "wasmbuilder": "^0.0.12",
-        "wasmcurves": "0.1.0",
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
         "web-worker": "^1.2.0"
       }
     },
@@ -3921,9 +3899,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -4152,6 +4130,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -4598,15 +4582,28 @@
       "dev": true
     },
     "r1csfile": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.37.tgz",
-      "integrity": "sha512-6Yb2SqWU59t7wWUX0/4BvVtWAN7RwkIobFJ90+RD3MB2Y5gb5aBGkFWJxDLqqWQbmQnv3y0ekpfDxbtNNAgrGw==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
+      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
       "dev": true,
       "requires": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.11",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.55"
+        "ffjavascript": "0.2.56"
+      },
+      "dependencies": {
+        "ffjavascript": {
+          "version": "0.2.56",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+          "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+          "dev": true,
+          "requires": {
+            "wasmbuilder": "0.0.16",
+            "wasmcurves": "0.2.0",
+            "web-worker": "^1.2.0"
+          }
+        }
       }
     },
     "randombytes": {
@@ -4637,12 +4634,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "readline": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
-      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -4703,70 +4694,32 @@
       }
     },
     "snarkjs": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.4.10.tgz",
-      "integrity": "sha512-YWgxso7CGcSfkyDGraVjPuBJtq6GEsZ16YBJj2eD0TFum2D5BxnawvyTo4p/7UpctAT0r05DoHo80zgaWnbIKA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
+      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
       "dev": true,
       "requires": {
-        "@iden3/binfileutils": "0.0.8",
-        "blake2b-wasm": "^2.3.0",
-        "circom_runtime": "0.1.14",
+        "@iden3/binfileutils": "0.0.11",
+        "bfj": "^7.0.2",
+        "blake2b-wasm": "^2.4.0",
+        "circom_runtime": "0.1.21",
         "ejs": "^3.1.6",
-        "fastfile": "0.0.19",
-        "ffjavascript": "0.2.39",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.2.56",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.33",
-        "readline": "^1.3.0"
+        "r1csfile": "0.0.41"
       },
       "dependencies": {
-        "@iden3/binfileutils": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.8.tgz",
-          "integrity": "sha512-/GqTsujUssGuQY+sd/XaLrA+OiCwzm+6yH28C57QQDWCHET2Logry9fGxU10n6XKdhCQBjZ7T/YMQkLwwkpRTQ==",
-          "dev": true,
-          "requires": {
-            "fastfile": "0.0.19",
-            "ffjavascript": "^0.2.30"
-          }
-        },
-        "fastfile": {
-          "version": "0.0.19",
-          "resolved": "https://registry.npmjs.org/fastfile/-/fastfile-0.0.19.tgz",
-          "integrity": "sha512-tz9nWR5KYb6eR2odFQ7oxqEkx8F3YQZ6NBJoJR92YEG3DqYOqyxMck8PKvTVNKx3uwvOqGnLXNScnqpdHRdHGQ==",
-          "dev": true
-        },
         "ffjavascript": {
-          "version": "0.2.39",
-          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.39.tgz",
-          "integrity": "sha512-9ewb5keKHL1owKTxCK7sDuA34SPJxnznWqdJgwBW51moCvg+wf9L0W5mcxm8qMUxt2OE/KjBQUKmYLaKyNNrPw==",
+          "version": "0.2.56",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
+          "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
           "dev": true,
           "requires": {
-            "big-integer": "^1.6.48",
-            "wasmcurves": "0.0.14",
-            "web-worker": "^1.0.0"
-          }
-        },
-        "r1csfile": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.33.tgz",
-          "integrity": "sha512-aSZa/Vy6avJ146MOewUNRYdDLJCDINZ7aqSt0Zhw4uVrd4TijOz6gBfmckr7tPILaT3RNp7THVpUzeW0++OlJw==",
-          "dev": true,
-          "requires": {
-            "@iden3/bigarray": "0.0.2",
-            "@iden3/binfileutils": "0.0.8",
-            "fastfile": "0.0.19",
-            "ffjavascript": "0.2.39"
-          }
-        },
-        "wasmcurves": {
-          "version": "0.0.14",
-          "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.0.14.tgz",
-          "integrity": "sha512-G1iMkxlRaQSdqQ1JrwHcU+awLmwyH6kFKfT8g9obd8MWe+u5oSdFXrODB0zmSI5aGGvJPG+4cAmqCGYv9R+7qg==",
-          "dev": true,
-          "requires": {
-            "big-integer": "^1.6.42",
-            "blakejs": "^1.1.0"
+            "wasmbuilder": "0.0.16",
+            "wasmcurves": "0.2.0",
+            "web-worker": "^1.2.0"
           }
         }
       }
@@ -4864,6 +4817,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4903,22 +4862,18 @@
       "dev": true
     },
     "wasmbuilder": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.12.tgz",
-      "integrity": "sha512-dTMpBgrnLOXrN58i2zakn2ScynsBhq9LfyQIsPz4CyxRF9k1GAORniuqn3xmE9NnI1l7g3iiVCkoB2Cl0/oG8w==",
-      "dev": true,
-      "requires": {
-        "big-integer": "^1.6.48"
-      }
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.16.tgz",
+      "integrity": "sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==",
+      "dev": true
     },
     "wasmcurves": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.1.0.tgz",
-      "integrity": "sha512-kIlcgbVUAv2uQ6lGsepGz/m5V40+Z6rvTBkqCYn3Y2+OcXst+UaP4filJYLh/xDxjJl62FFjZZeAnpeli1Y5/Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
+      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
       "dev": true,
       "requires": {
-        "big-integer": "^1.6.42",
-        "blakejs": "^1.1.0"
+        "wasmbuilder": "0.0.16"
       }
     },
     "web-worker": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "blake-hash": "^2.0.0",
     "chai": "^4.3.4",
-    "circom_tester": "0.0.13",
+    "circom_tester": "0.0.19",
     "circomlibjs": "^0.1.4",
     "mocha": "^9.1.3"
   }


### PR DESCRIPTION
This PR fixes `npm run test`.
The following errors show in current version.
```
     LinkError: WebAssembly.instantiate(): Import #1 module="runtime" function="printErrorMessage" error: function import requires a callable
      at builder (node_modules/circom_tester/wasm/witness_calculator.js:19:40)
      at async wasm_tester (node_modules/circom_tester/wasm/tester.js:60:16)
      at async Context.<anonymous> (test/smtprocessor.js:97:19)
```