### PR TITLE
bump circom_tester version to work with circom 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "blake-hash": "^2.0.0",
         "chai": "^4.3.4",
-        "circom_tester": "0.0.13",
+        "circom_tester": "0.0.15",
         "circomlibjs": "^0.1.4",
         "mocha": "^9.1.3"
       }
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/circom_tester": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.13.tgz",
-      "integrity": "sha512-VV6SeU28wGouPRKdcoHYAmbtVCW3pXW1nuFRmpn+7xakeNKuHDw6ECK7LDeBdJw3s9I5hwxQkkw5J9Letxt6hg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.15.tgz",
+      "integrity": "sha512-cgU7i0fE5nh7zakrIMW6qeiuA9H15P7Ku71LdceA+XaMKo77Wn07C1ugEPMEqETwGDbr1pRzlVJ3oIVAQoY5LA==",
       "dev": true,
       "dependencies": {
         "chai": "^4.3.4",
@@ -3647,9 +3647,9 @@
       }
     },
     "circom_tester": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.13.tgz",
-      "integrity": "sha512-VV6SeU28wGouPRKdcoHYAmbtVCW3pXW1nuFRmpn+7xakeNKuHDw6ECK7LDeBdJw3s9I5hwxQkkw5J9Letxt6hg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/circom_tester/-/circom_tester-0.0.15.tgz",
+      "integrity": "sha512-cgU7i0fE5nh7zakrIMW6qeiuA9H15P7Ku71LdceA+XaMKo77Wn07C1ugEPMEqETwGDbr1pRzlVJ3oIVAQoY5LA==",
       "dev": true,
       "requires": {
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "blake-hash": "^2.0.0",
     "chai": "^4.3.4",
-    "circom_tester": "0.0.13",
+    "circom_tester": "0.0.15",
     "circomlibjs": "^0.1.4",
     "mocha": "^9.1.3"
   }


### PR DESCRIPTION
The goal of this PR is to make `npm test` work again with newer versions of circom.

With the old version of cirom_tester and circom 2.1.2, the following error message was shown:
`LinkError: WebAssembly.instantiate(): Import #1 module="runtime" function="printErrorMessage" error: function import requires a callable`

The change was tested with circom 2.1.2. Hopefully (not yet tested) it works with other 2.1.x version and keeps working with 2.0.x.