### PR TITLE
Improve MultiAND

### DIFF
--- a/circuits/gates.circom
+++ b/circuits/gates.circom
@@ -68,29 +68,15 @@ template NOR() {
 template MultiAND(n) {
     signal input in[n];
     signal output out;
-    component and1;
-    component and2;
-    component ands[2];
-    if (n==1) {
-        out <== in[0];
-    } else if (n==2) {
-        and1 = AND();
-        and1.a <== in[0];
-        and1.b <== in[1];
-        out <== and1.out;
-    } else {
-        and2 = AND();
-        var n1 = n\2;
-        var n2 = n-n\2;
-        ands[0] = MultiAND(n1);
-        ands[1] = MultiAND(n2);
-        var i;
-        for (i=0; i<n1; i++) ands[0].in[i] <== in[i];
-        for (i=0; i<n2; i++) ands[1].in[i] <== in[n1+i];
-        and2.a <== ands[0].out;
-        and2.b <== ands[1].out;
-        out <== and2.out;
+
+    signal outs[n];
+    outs[0] <== in[0];
+
+    for (var i = 1; i < n; i++) {
+        outs[i] <== outs[i - 1] * in[i];
     }
+
+    out <== outs[n - 1];
 }
 
 


### PR DESCRIPTION
# Summary

Improve MultiAND for better readability and fewer instances/labels

# Description

The previous version of `MultiAND` used recursion to calculate AND(a1,a2,a3,...,an), while this one uses a temporary array of `n` values and multiplies them all. Testing it with `n=3`, it also reduces the number of instances and labels.

## Previous version

<img width="463" alt="previous" src="https://github.com/iden3/circomlib/assets/3029017/7d4b36cb-4ea5-4072-9b08-b8ff830e0c9d">


## New version

<img width="440" alt="new" src="https://github.com/iden3/circomlib/assets/3029017/5441f869-8f75-4454-9f20-548cf89f6e5e">
