### PR TITLE
Added input bit validation in template Bits2Num

### DIFF
--- a/circuits/bitify.circom
+++ b/circuits/bitify.circom
@@ -59,6 +59,7 @@ template Bits2Num(n) {
 
     var e2 = 1;
     for (var i = 0; i<n; i++) {
+        in[i] * (in[i] - 1) === 0;
         lc1 += in[i] * e2;
         e2 = e2 + e2;
     }


### PR DESCRIPTION
Fixed templates Bits2Num and Bits2Num_strict by adding an input bit validation. Before this change, the template did accept values different from 0 and 1 leading to wrong results. The templates should fail the assertion if any of the input bits is neither 0 nor 1.