### PR TITLE
remove non-existant folders from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 This respository contains 5 folders:
 - `circuits`: it contains the implementation of different cryptographic primitives in circom language.
-- `calcpedersenbases`: set of functions in JavaScript used to find a set of points in [Baby Jubjub](https://github.com/barryWhiteHat/baby_jubjub) elliptic curve that serve as basis for the [Pedersen Hash](https://github.com/zcash/zcash/issues/2234).
 - `doc`: it contains some circuit schemes in ASCII (must be opened with Monodraw, an ASCII art editor for Mac).
-- `src`: it contains similar implementation of circuits in JavaScript.
 - `test`: tests.
 
 A description of the specific circuit templates for the `circuit` folder will be soon updated.


### PR DESCRIPTION
Removed three folders from the README that are said to be part of the repo's structure but are not (anymore).