### PR TITLE
Switch from blake-hash to audited noble-hashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "author": "0Kims",
   "license": "GPL-3.0",
   "devDependencies": {
-    "blake-hash": "^2.0.0",
+    "@noble/hashes": "^1.7.1",
     "chai": "^4.3.4",
-    "circom_tester": "0.0.13",
+    "circom_tester": "0.0.20",
     "circomlibjs": "^0.1.4",
     "mocha": "^9.1.3"
   }

--- a/test/babyjub.js
+++ b/test/babyjub.js
@@ -1,7 +1,7 @@
 const chai = require("chai");
 const path = require("path");
 
-const createBlakeHash = require("blake-hash");
+const { blake512 } = require('@noble/hashes/blake1');
 const buildEddsa = require("circomlibjs").buildEddsa;
 
 const assert = chai.assert;
@@ -99,7 +99,7 @@ describe("Baby Jub test", function () {
     it("Should extract the public key from the private one", async () => {
 
         const rawpvk = Buffer.from("0001020304050607080900010203040506070809000102030405060708090021", "hex");
-        const pvk    = eddsa.pruneBuffer(createBlakeHash("blake512").update(rawpvk).digest().slice(0,32));
+        const pvk    = eddsa.pruneBuffer(blake512(rawpvk).slice(0,32));
         const S      = Scalar.shr(utils.leBuff2int(pvk), 3);
 
         const A      = eddsa.prv2pub(rawpvk);


### PR DESCRIPTION
noble cryptography is high-security, easily auditable set of contained cryptographic libraries and tools.

noble-hashes (https://github.com/paulmillr/noble-hashes) has blake1. It would be great to use it instead of some unknown library.