### PR TITLE
Fixed typos

### DIFF
--- a/circuits/README.md
+++ b/circuits/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 - This folder contains circuit templates for standard operations and many cryptographic primitives.
-- Below you can find specifications of each function. In the representation of elements, there are three tyes:
+- Below you can find specifications of each function. In the representation of elements, there are three types, ties:
     - Binary
     - String
     - Field element (the field is specified in each case. We consider 2 possible fields: Fp and Fr, where p... and r... .)


### PR DESCRIPTION
### Changes

1. **File:** `/circuits/README.md`
    - Fixed `tyes` to `types, ties` (Line 6)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.