### PR TITLE
Optimize BabyDbl implementation for constraint efficiency

### DIFF
--- a/circuits/babyjub.circom
+++ b/circuits/babyjub.circom
@@ -55,14 +55,22 @@ template BabyDbl() {
     signal output xout;
     signal output yout;
 
-    component adder = BabyAdd();
-    adder.x1 <== x;
-    adder.y1 <== y;
-    adder.x2 <== x;
-    adder.y2 <== y;
+    var a = 168700;
+    var d = 168696;
+    signal x2 <== x * x;
+    signal y2 <== y * y;
+    signal xy <== x * y;
+    signal xy2 <== xy * xy;
 
-    adder.xout ==> xout;
-    adder.yout ==> yout;
+    signal denomx <== 1 + d * xy2;
+    signal denomy <== 1 - d * xy2;
+
+
+    xout <-- (2 * xy) / denomx;
+    yout <-- (y2 - a * x2) / denomy;
+
+    denomx * xout === 2 * xy;
+    denomy * yout === y2 - a * x2;
 }
 
 


### PR DESCRIPTION
Replace the current BabyDbl implementation with an optimized version that directly implements Edwards doubling formulas rather than reusing BabyAdd. This improves constraint efficiency by getting rid of unnecessary intermediate calculations.