### PR TITLE
Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true


### PR DESCRIPTION
Updated actions/checkout and actions/setup-node to v4 in our CI workflows to stay current with the latest versions.

[actions/checkout@v4 Release Notes](https://github.com/actions/checkout/releases/tag/v4.2.2)
[actions/setup-node@v4 Release Notes](https://github.com/actions/setup-node/releases/tag/v4.4.0)