### PR TITLE
General Aliascheck template

### DIFF
--- a/circuits/aliascheck.circom
+++ b/circuits/aliascheck.circom
@@ -16,18 +16,140 @@
     You should have received a copy of the GNU General Public License
     along with circom. If not, see <https://www.gnu.org/licenses/>.
 */
-pragma circom 2.0.0;
+pragma circom 2.2.0;
 
-include "compconstant.circom";
+include "comparators.circom";
+
+function maxbits(){
+    var n = 1;
+    var r = 1;
+    while(2 * n > n){
+        n = n * 2;
+        r = r + 1;
+    }
+    return r + 1;
+}
 
 
-template AliasCheck() {
+function num2bits_function(n, nBits) {
+    var bits[maxbits()];
+    var acc = n;
 
-    signal input in[254];
+    for (var i = 0; i < nBits; i++) {
+        bits[i] = acc % 2;
+        acc = acc \ 2; // In Circom, \ performs integer division
+    }
 
-    component  compConstant = CompConstant(-1);
+    return bits;
+}
 
-    for (var i=0; i<254; i++) in[i] ==> compConstant.in[i];
 
-    compConstant.out === 0;
+template AliasCheck(){
+
+   // First we bitify the value of p-1. As it is a constant, we call to the auxiliar function to_bits
+   var bits = maxbits();
+   var p_to_bits[bits] = num2bits_function(-1, bits);
+
+   signal input in[bits];
+   
+   
+   // consider the most significant bit and open the first group
+   var prev_bit = p_to_bits[0];
+   var sum_group = in[0];
+   var size_window = 1;
+   
+   var num_conds = 0;
+   
+   signal conds[bits];
+   
+   
+   for (var i = 1; i < bits; i++){
+      if (prev_bit == p_to_bits[i]){
+         // does not change the bit, continue in the same group. We update the sum adding the new value
+         sum_group += in[i];
+         size_window += 1;
+      }
+      
+      else{
+         // the bit changes, we close the previous group adding the condition and open a new window
+         if (prev_bit == 0){
+            // we close a window of 0s
+            if (size_window > 1){
+               conds[num_conds] <== IsZero()(sum_group);
+            } else{
+               conds[num_conds] <== 1 - sum_group;
+            }
+         } else{
+            // we close a window of 1s
+            if (size_window > 1){
+               conds[num_conds] <== IsEqual()([sum_group, size_window]);
+            } else{
+               conds[num_conds] <== sum_group;
+            }
+         }
+         
+         num_conds += 1;
+
+         // we open the new window
+         prev_bit = p_to_bits[i];
+         sum_group = in[i];
+         size_window = 1;
+      }
+
+   }
+   
+   // Finally we close the last window
+   if (prev_bit == 0){
+      // we close a window of 0s
+      if (size_window > 1){
+         conds[num_conds] <== IsZero()(sum_group);
+      } else{
+         conds[num_conds] <== 1 - sum_group;
+      }
+
+      num_conds += 1;
+     
+   } else{
+      // we close a window of 1s
+      if (size_window > 1){
+         conds[num_conds] <== IsEqual()([sum_group, size_window]);
+      } else{
+         conds[num_conds] <== sum_group;
+      }
+      
+      num_conds += 1;
+
+   }
+
+
+   // Now we generate the condition stating that the in should be smaller or equal than p-1
+   signal acum_result[num_conds];
+   prev_bit = p_to_bits[0];
+
+   if (prev_bit == 0){ // number with first window being a 0
+      acum_result[0] <== 1 - conds[0];
+      prev_bit = 1;
+   } else if (prev_bit == 1){
+      acum_result[0] <== conds[0];
+      prev_bit = 0;
+   }
+
+   var index = 1;
+
+
+   while(index < num_conds){
+      if (prev_bit == 0){ // number with last window being a 0
+         acum_result[index] <== (1 - conds[index]) + acum_result[index-1] ;
+         prev_bit = 1;
+      } else if (prev_bit == 1){
+         acum_result[index] <== conds[index] * acum_result[index-1];
+         prev_bit = 0;
+      }
+      index += 1;
+   }
+   
+   // We add the condition stating that the result should be <= p-1
+   acum_result[num_conds - 1] === 0;
+
+
 }


### PR DESCRIPTION
This PR introduces an improved version of the Aliascheck() template. This implementation overcomes two major limitations of the current circomlib implementation:

1. Flexibility: the current version of the Aliascheck template only works for the bn128 finite field and produces incorrect results if it is applied to other finite fields. While there are other implementations of the Aliascheck template for other finite fields, this PR introduces the first generalized implementation that can be applied to any finite field.

2. Performance: the new template significantly reduces the number of non-linear R1CS constraints required, lowering circuit compilation and proving costs. 

The reductions obtained for the goldilocks and bn128 primes are the following:

### Non-linear constraints

| Prime / Field | Previous | Now |
| :--- | :--- | :--- |
| goldilocks | 65 | 5 |
| bn128 | 262 | 169 |

## Intuition: 

To verify that an input $x$ is valid and cannot be used in an alias attack, we must ensure that $x \le p - 1$. Instead of performing this check bit-by-bit, we decompose $C = p - 1$ into its Run-Length Encoding (RLE) of contiguous identical bits. Then, let $n$ be the number of blocks $C$, we split the bits of the input in the same $n$ blocks, and we get $C_0,...,C_{n-1}$ from $C$ and $B_0,...,B_{n-1}$ from the input. We then perform comparisons on these blocks:

### Block comparison
* If $C_i$ is a block of 1's: We compute the sum of the bits of the input block $B_i$. We check if all bits are 1 by comparing whether the sum equals the block length. If so, the block $B_i$ matches the corresponding block $C_i$. Otherwise, it is smaller.
* If $C_i$ is a block of 0's in $C$: We compute the sum of the bits of the input in that block. We check if all bits are 0 by comparing whether the sum is zero. If so, the block $B_i$ matches the corresponding block $C_i$. If not, it is greater.

* Optimization: If a block is only 1 bit long, we evaluate the bit directly.

### Chain comparison
We aggregate the comparison results of the blocks backwards from the LSB to the MSB. Let n be the number of blocks of $C$. Then for all i in {0..m-1} the signal accum[i] is 0 if and only if  $B_0,...,B_i$ is smaller than or equal to $C_0,...,C_i$.
We encode this as follows:
* If C_i is a block of 0's : We add the negation of the block-match result to accum[i-1] (if i>0). The output is 0 if and only if the $B_i$ matches $C_i$ and $B_0,...,B_i$ is smaller than or equal to $C_0,...,C_i$ (which fulfils the specification).
* If C_i is a block of $1$'s : We multiply the block-match result and accum[i-1] (if i>0). The output is 0 if and only if either $B_i$ is smaller than $C_i$ or they are equal and $B_0,...,B_i$ is smaller than or equal to $C_0,...,C_i$ (which fulfils the specification).


## Number of non-linear constraints

The number of non-linear constraints in the template depends on the number of blocks in the decomposition of $p - 1$. We can compute it as follows:

$$
C_{\text{NL}} = 2 \cdot B_{\text{size}>1} + \frac{B}{2}
$$

where $C_{\text{NL}}$ is the number of non-linear constraints in the R1CS system, $B_{\text{size}>1}$ is the number of blocks in the decomposition of $p - 1$ with a size greater than 1, and $B$ is the total number of blocks in the decomposition.